### PR TITLE
Convert retry interval to millis in init

### DIFF
--- a/src/lager_humio_backend.erl
+++ b/src/lager_humio_backend.erl
@@ -167,7 +167,7 @@ call_ingest_api(Request, Retries, Interval, Opts) ->
         {ok, {{_, 200, _}, _H, _B}} ->
             ok;
         _Other ->
-            timer:sleep(Interval * 1000),
+            timer:sleep(Interval),
             call_ingest_api(Request, Retries - 1, Interval, Opts)
     end.
 
@@ -231,7 +231,7 @@ get_configuration(Options) ->
           , formatter       = get_option(formatter, Options, lager_default_formatter)
           , format_config   = get_option(format_config, Options, [])
           , metadata_filter = get_option(metadata_filter, Options, [])
-          , retry_interval  = get_option(retry_interval, Options, 60)
+          , retry_interval  = get_option(retry_interval, Options, 60) * 1000
           , max_retries     = get_option(max_retries, Options, 10)
           , httpc_opts      = get_option(httpc_opts, Options, [])
           }.

--- a/test/lager_humio_backend_tests.erl
+++ b/test/lager_humio_backend_tests.erl
@@ -103,7 +103,7 @@ test_call_ingest_api_retry() ->
           ),
 
     %% tests case when we hit maximum number of retries
-    ?assertEqual(ok, lager_humio_backend:call_ingest_api(Request, 0, 10, [])),
+    ?assertEqual(ok, lager_humio_backend:call_ingest_api(Request, 0, 1, [])),
 
     %% tests case when we hit maximum number of retries
     ?assertEqual(ok, lager_humio_backend:call_ingest_api(Request, 3, 1, [])),
@@ -124,7 +124,7 @@ test_get_configuration() ->
               ],
 
     ?assertEqual(
-       {state, [], [], [], 128, lager_default_formatter, [], [], 60, 10, []},
+       {state, [], [], [], 128, lager_default_formatter, [], [], 60*1000, 10, []},
        lager_humio_backend:get_configuration(Options)
       ).
 


### PR DESCRIPTION
Now we only do the conversion once instead of for every event.  A
minor performance improvement, but more importantly, and the reason
for the change, the unit test is much faster.